### PR TITLE
Hotfix for auto width update

### DIFF
--- a/dist/wave.js
+++ b/dist/wave.js
@@ -87,6 +87,9 @@ var Wave = (function () {
       Wave.prototype.init = function () {
           if (this.container.querySelector('canvas') === null) {
               var canvas = document.createElement('canvas');
+              // Set an unique ID
+              var canvasID = "canvasWaveJs";
+                canvas.setAttribute("id", canvasID);  
               this.container.appendChild(canvas);
           }
           this.canvas = this.container.querySelector('canvas');
@@ -94,6 +97,22 @@ var Wave = (function () {
           this.canvas.height = this.container.offsetHeight;
           this.ctx = this.canvas.getContext('2d');
           this.setLines();
+
+          // Get the Canvas element by ID
+            var getCanvasElement = document.getElementById(canvasID);
+          
+          // Save window width 
+            var actualWindowWidth = getCanvasElement.parentNode.offsetWidth;
+
+            // Watch if the width changes 
+              window.onresize = function(){
+                var canvasParentNodeWidth = getCanvasElement.parentNode.offsetWidth;
+                
+                //if it does, compare the saved Canvas width with the new  Canvas width
+                  if (canvasParentNodeWidth > actualWindowWidth) {
+                      getCanvasElement.width = canvasParentNodeWidth;
+                }
+              }
       };
       Wave.prototype.animate = function () {
           this.status = 'animating';


### PR DESCRIPTION
First of all, I would like to thank you for this incredible and flexible tool of yours. It helped and saved me from hours. Thank you.

When testing this tool, I have noticed that when the page loads, the canvas gets the width of its parent. However, in case the page is resized to a greater width, the canvas width isn't updated in case the parent width exceeds the canvas width. 
Here is a way to replicate it: 

- Change the browser width (e.g 320px)
- Refresh the browser so the canvas can get a new width (from its parent)
- Change the browser width to a greater value (e.g 400px) without refreshing it

After the above steps, you will notice that the canvas width stays the same, while its parent grows.
